### PR TITLE
Fix sendMessageStream usecase complexity and ID confusion

### DIFF
--- a/src/app/api/messages/stream/route.ts
+++ b/src/app/api/messages/stream/route.ts
@@ -70,17 +70,18 @@ export async function GET(request: NextRequest) {
             })}\n\n`;
             controller.enqueue(encoder.encode(errorData));
           } else {
-            const { session, claudeResponse } = result.value;
+            const { session, claudeResult } = result.value;
             const completeData = `data: ${JSON.stringify({
               type: "complete",
               sessionId: session.id,
               projectId: session.projectId,
-              content: claudeResponse.content,
+              content: claudeResult.lastAssistantMessage?.content || [],
               metadata: {
-                id: claudeResponse.id,
-                model: claudeResponse.model,
-                stop_reason: claudeResponse.stop_reason,
-                usage: claudeResponse.usage,
+                id: claudeResult.lastAssistantMessage?.id || "",
+                model: claudeResult.lastAssistantMessage?.model || "",
+                stop_reason:
+                  claudeResult.lastAssistantMessage?.stop_reason || null,
+                usage: claudeResult.usage,
               },
             })}\n\n`;
             controller.enqueue(encoder.encode(completeData));

--- a/src/core/application/claude/sendMessageStream.test.ts
+++ b/src/core/application/claude/sendMessageStream.test.ts
@@ -55,8 +55,8 @@ describe("sendMessageStream", () => {
       if (result.isOk()) {
         expect(result.value.session).toBeDefined();
         expect(result.value.session.projectId).toBe(project.id);
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
 
         // Check that onChunk was called with streaming data
         expect(onChunkSpy).toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe("sendMessageStream", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(result.value.session.id).toBe("session-123");
-        expect(result.value.claudeResponse).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });
@@ -126,13 +126,14 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        // Mock streams "You said: Multi word message" as separate chunks
+        // Mock streams "You said: Multi word message" as separate chunks in NDJSON format
         const chunks = onChunkSpy.mock.calls.map((call) => call[0]);
-        expect(chunks.some((chunk) => chunk.includes("You"))).toBe(true);
-        expect(chunks.some((chunk) => chunk.includes("said:"))).toBe(true);
-        expect(chunks.some((chunk) => chunk.includes("Multi"))).toBe(true);
-        expect(chunks.some((chunk) => chunk.includes("word"))).toBe(true);
-        expect(chunks.some((chunk) => chunk.includes("message"))).toBe(true);
+        const joinedChunks = chunks.join("");
+        expect(joinedChunks.includes("You")).toBe(true);
+        expect(joinedChunks.includes("said:")).toBe(true);
+        expect(joinedChunks.includes("Multi")).toBe(true);
+        expect(joinedChunks.includes("word")).toBe(true);
+        expect(joinedChunks.includes("message")).toBe(true);
       }
     });
 
@@ -225,8 +226,8 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });
@@ -257,8 +258,19 @@ describe("sendMessageStream", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(chunks.length).toBeGreaterThan(0);
-        const fullStreamedText = chunks.join("");
-        expect(fullStreamedText.trim()).toBe("You said: Test streaming");
+        // Parse NDJSON chunks and extract text content
+        const textChunks = chunks
+          .map((chunk) => {
+            try {
+              const parsed = JSON.parse(chunk);
+              return parsed.type === "text" ? parsed.text : "";
+            } catch {
+              return "";
+            }
+          })
+          .filter((text) => text.length > 0);
+        const combinedText = textChunks.join("").trim();
+        expect(combinedText).toBe("You said: Test streaming");
       }
     });
   });
@@ -411,8 +423,8 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });
@@ -438,8 +450,8 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });
@@ -465,7 +477,7 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });
@@ -491,8 +503,8 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });
@@ -519,8 +531,8 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
       }
     });
 
@@ -545,8 +557,8 @@ describe("sendMessageStream", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.claudeResponse).toBeDefined();
-        expect(result.value.claudeResponse.content).toBeDefined();
+        expect(result.value.claudeResult).toBeDefined();
+        expect(result.value.claudeResult.lastAssistantMessage).toBeDefined();
         expect(onChunkSpy).toHaveBeenCalled();
       }
     });

--- a/src/core/domain/claude/ports/claudeService.ts
+++ b/src/core/domain/claude/ports/claudeService.ts
@@ -1,16 +1,14 @@
 import type { Result } from "neverthrow";
 import type { ClaudeError } from "@/lib/error";
-import type { ClaudeMessage, ClaudeResponse, SendMessageInput } from "../types";
+import type { ClaudeQueryResult, SendMessageInput } from "../types";
 
 export interface ClaudeService {
   sendMessage(
     input: SendMessageInput,
-    messages: ClaudeMessage[],
-  ): Promise<Result<ClaudeResponse, ClaudeError>>;
+  ): Promise<Result<ClaudeQueryResult, ClaudeError>>;
 
   sendMessageStream(
     input: SendMessageInput,
-    messages: ClaudeMessage[],
     onChunk: (chunk: string) => void,
-  ): Promise<Result<ClaudeResponse, ClaudeError>>;
+  ): Promise<Result<ClaudeQueryResult, ClaudeError>>;
 }

--- a/src/core/domain/claude/types.ts
+++ b/src/core/domain/claude/types.ts
@@ -1,3 +1,4 @@
+import type { SDKMessage } from "@anthropic-ai/claude-code";
 import { z } from "zod/v4";
 
 export const sendMessageInputSchema = z.object({
@@ -8,13 +9,31 @@ export const sendMessageInputSchema = z.object({
 });
 export type SendMessageInput = z.infer<typeof sendMessageInputSchema>;
 
+// Use SDK types directly instead of custom types
+export type ClaudeSDKMessage = SDKMessage;
+
+// Result type that contains all SDK messages
+export const claudeQueryResultSchema = z.object({
+  messages: z.array(z.any()), // SDKMessage array
+  lastAssistantMessage: z.any().optional(), // Optional assistant message
+  usage: z
+    .object({
+      input_tokens: z.number(),
+      output_tokens: z.number(),
+      cache_creation_input_tokens: z.number().optional(),
+      cache_read_input_tokens: z.number().optional(),
+    })
+    .optional(),
+});
+export type ClaudeQueryResult = z.infer<typeof claudeQueryResultSchema>;
+
+// Legacy types - deprecated, use SDK types instead
 export const claudeMessageSchema = z.object({
   role: z.enum(["user", "assistant"]),
   content: z.string(),
 });
 export type ClaudeMessage = z.infer<typeof claudeMessageSchema>;
 
-// Content block schemas based on Anthropic SDK
 export const textBlockSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
@@ -36,7 +55,6 @@ export const contentBlockSchema = z.union([
   textBlockSchema,
   toolUseBlockSchema,
   thinkingBlockSchema,
-  // Allow other content types as well
   z
     .object({
       type: z.string(),
@@ -64,7 +82,6 @@ export const claudeResponseSchema = z.object({
 });
 export type ClaudeResponse = z.infer<typeof claudeResponseSchema>;
 
-// Helper type definitions
 export type TextBlock = z.infer<typeof textBlockSchema>;
 export type ToolUseBlock = z.infer<typeof toolUseBlockSchema>;
 export type ThinkingBlock = z.infer<typeof thinkingBlockSchema>;

--- a/src/core/domain/session/types.ts
+++ b/src/core/domain/session/types.ts
@@ -1,3 +1,4 @@
+import { v7 as uuidv7 } from "uuid";
 import { z } from "zod/v4";
 import { paginationSchema } from "@/lib/pagination";
 import { type ProjectId, projectIdSchema } from "../project/types";
@@ -46,4 +47,8 @@ export type ListSessionQuery = z.infer<typeof listSessionQuerySchema>;
 
 export function getSessionDisplayName(name: string | null): string {
   return name || "Untitled Session";
+}
+
+export function generateSessionId(): SessionId {
+  return sessionIdSchema.parse(uuidv7());
 }


### PR DESCRIPTION
## Summary

- Refactor `sendMessageStream` usecase to use SDK types directly and eliminate ID confusion
- Generate session IDs independently from Claude API message IDs  
- Simplify interfaces by leveraging Claude Code SDK types instead of custom transformations

## Changes Made

### 🔧 Core Architecture Changes
- **New `ClaudeQueryResult` type**: Uses SDK message types directly instead of custom conversions
- **Independent session ID generation**: Uses UUID v7 instead of Claude API message IDs
- **Simplified `ClaudeService` interface**: Removed unnecessary message parameter and reduced complexity

### 🏗️ Implementation Updates
- **sendMessageStream usecase**: Eliminated object conversion issues and ID mixing
- **AnthropicClaudeService**: Direct SDK message handling without extra transformations  
- **MockClaudeService**: Updated to match new interface with NDJSON streaming format
- **API endpoint**: Updated to use new result structure

### ✅ Testing & Quality
- **All tests updated**: Reflect new interface and NDJSON chunk format
- **Type safety improved**: Better leverage of SDK types reduces conversion errors
- **Code quality**: Passes TypeScript checks and linting

## Test Plan

- [x] All existing tests pass with new interface
- [x] TypeScript compilation succeeds 
- [x] Linting passes without warnings
- [x] Session ID generation works independently
- [x] Streaming functionality maintains NDJSON format
- [x] Mock service properly simulates new behavior

🤖 Generated with [Claude Code](https://claude.ai/code)