### PR TITLE
feat: rename package from claude-code-watcher to cc-jsonl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Code Watcher
+# cc-jsonl
 
 A unified CLI tool for processing Claude Code log files and managing production servers.
 
@@ -15,19 +15,19 @@ A unified CLI tool for processing Claude Code log files and managing production 
 
 ```bash
 # 1. Install globally
-npm install -g claude-code-watcher
+npm install -g cc-jsonl
 
 # 2. Initialize configuration and database
-claude-code-watcher setup
+cc-jsonl setup
 
 # 3. Start production server
-claude-code-watcher start
+cc-jsonl start
 
 # 4. Process log files once
-claude-code-watcher batch
+cc-jsonl batch
 
 # 5. Monitor and process log files continuously
-claude-code-watcher watch
+cc-jsonl watch
 ```
 
 ## Installation
@@ -39,10 +39,10 @@ claude-code-watcher watch
 ### Global Installation (Recommended)
 ```bash
 # Install globally for system-wide access
-npm install -g claude-code-watcher
+npm install -g cc-jsonl
 
 # Verify installation
-claude-code-watcher --version
+cc-jsonl --version
 ```
 
 ### Initial Setup
@@ -51,13 +51,13 @@ After installation, initialize the configuration and database:
 
 ```bash
 # Initialize with default settings
-claude-code-watcher setup
+cc-jsonl setup
 
-# Initialize with custom paths
-claude-code-watcher setup --databaseFile /custom/path/data.db --watchDir /custom/logs
+# Initialize with custom paths and port
+cc-jsonl setup --databaseFile /custom/path/data.db --watchDir /custom/logs --port 8080
 
-# Force overwrite existing configuration
-claude-code-watcher setup --force
+# Force overwrite existing configuration (when config already exists)
+cc-jsonl setup --force
 ```
 
 **Configuration locations (follows XDG Base Directory specification):**
@@ -68,8 +68,8 @@ claude-code-watcher setup --force
 ### Alternative: NPX Usage
 ```bash
 # Use without installation
-npx claude-code-watcher --help
-npx claude-code-watcher start --port 8080
+npx cc-jsonl --help
+npx cc-jsonl start --port 8080
 ```
 
 ## Usage
@@ -80,11 +80,11 @@ Run the web application in production environment:
 
 ```bash
 # Start on default port (3000)
-claude-code-watcher start
+cc-jsonl start
 
 # Start on custom port
-claude-code-watcher start --port 8080
-claude-code-watcher start -p 3001
+cc-jsonl start --port 8080
+cc-jsonl start -p 3001
 ```
 
 ### Log File Processing
@@ -93,34 +93,37 @@ claude-code-watcher start -p 3001
 Process accumulated log files once and exit - perfect for cleaning up past logs:
 
 ```bash
-# Basic usage
-claude-code-watcher batch /path/to/claude-logs
+# Basic usage with configured directory
+cc-jsonl batch
 
-# With options
-claude-code-watcher batch -c 10 -p "*.jsonl" /path/to/claude-logs
+# Process specific directory
+cc-jsonl batch --targetDirectory /path/to/claude-logs
+
+# With concurrency and pattern options
+cc-jsonl batch --targetDirectory /path/to/claude-logs -c 10 -p "*.jsonl"
 
 # Reprocess all files including already processed ones
-claude-code-watcher batch --no-skipExisting /path/to/claude-logs
+cc-jsonl batch --targetDirectory /path/to/claude-logs --skipExisting false
 
 # Process only specific pattern files
-claude-code-watcher batch --pattern "session-*.jsonl" /path/to/claude-logs
+cc-jsonl batch --targetDirectory /path/to/claude-logs --pattern "session-*.jsonl"
 ```
 
 #### Continuous Monitoring (Watch)
 Monitor directory periodically and automatically process new files - ideal for real-time processing:
 
 ```bash
-# Basic usage - check every 60 minutes (default)
-claude-code-watcher watch /path/to/claude-logs
+# Basic usage - check every 60 minutes (default) with configured directory
+cc-jsonl watch
 
-# Check every 30 minutes
-claude-code-watcher watch -i 30 /path/to/claude-logs
+# Process specific directory every 30 minutes
+cc-jsonl watch --targetDirectory /path/to/claude-logs -i 30
 
 # High-frequency processing - 20 parallel processes every 5 minutes
-claude-code-watcher watch -c 20 -i 5 /path/to/claude-logs
+cc-jsonl watch --targetDirectory /path/to/claude-logs -c 20 -i 5
 
 # Monitor specific patterns every 15 minutes
-claude-code-watcher watch -p "**/*.jsonl" -i 15 /path/to/claude-logs
+cc-jsonl watch --targetDirectory /path/to/claude-logs -p "**/*.jsonl" -i 15
 ```
 
 ## Command Reference
@@ -129,10 +132,11 @@ claude-code-watcher watch -p "**/*.jsonl" -i 15 /path/to/claude-logs
 
 | Command | Description | Usage |
 |---------|-------------|-------|
-| `setup` | Initialize configuration and run database migrations | `claude-code-watcher setup [options]` |
-| `start` | Start production server | `claude-code-watcher start [options]` |
-| `batch` | Process log files once and exit | `claude-code-watcher batch [options] [directory]` |
-| `watch` | Process log files periodically | `claude-code-watcher watch [options] [directory]` |
+| `setup` | Initialize configuration and run database migrations | `cc-jsonl setup [options]` |
+| `build` | Build the Next.js application for production | `cc-jsonl build` |
+| `start` | Start production server | `cc-jsonl start [options]` |
+| `batch` | Process log files once and exit | `cc-jsonl batch [options]` |
+| `watch` | Process log files periodically | `cc-jsonl watch [options]` |
 
 ### Global Options
 
@@ -147,23 +151,39 @@ claude-code-watcher watch -p "**/*.jsonl" -i 15 /path/to/claude-logs
 |--------|-------|-------------|---------|
 | `--databaseFile` | `-d` | Database file path | `$XDG_CONFIG_HOME/cc-jsonl/data.db` or `~/.config/cc-jsonl/data.db` |
 | `--watchDir` | `-w` | Directory to watch for log files | `$XDG_CONFIG_HOME/claude/projects` or `~/.claude/projects` |
+| `--port` | `-p` | Port for the production server | 3000 |
 | `--force` | `-f` | Force overwrite existing configuration | false |
+
+### Build Command Options
+
+The `build` command has no options and simply builds the Next.js application for production.
 
 ### Production Server Options
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--port` | `-p` | Server port | 3000 |
+| `--port` | `-p` | Server port | Uses configured port or 3000 |
 
 ### Log Processing Options
 
+**Batch Command Options:**
+
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--targetDirectory` | - | Target directory to process | Configured watch directory |
+| `--targetDirectory` | - | Directory to process | Uses configured watch directory or WATCH_TARGET_DIR |
 | `--maxConcurrency` | `-c` | Maximum concurrent processing | 5 |
 | `--skipExisting` | `-s` | Skip already processed files | true |
 | `--pattern` | `-p` | File pattern to match | `**/*.jsonl` |
-| `--interval` | `-i` | Processing interval (watch only, minutes) | 60 |
+
+**Watch Command Options:**
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--targetDirectory` | - | Directory to process | Uses configured watch directory or WATCH_TARGET_DIR |
+| `--maxConcurrency` | `-c` | Maximum concurrent processing | 5 |
+| `--skipExisting` | `-s` | Skip already processed files | true |
+| `--pattern` | `-p` | File pattern to match | `**/*.jsonl` |
+| `--interval` | `-i` | Processing interval in minutes | 60 |
 
 ## Configuration
 
@@ -173,7 +193,7 @@ The recommended way to configure Claude Code Watcher is using the setup command,
 
 ```bash
 # Initialize configuration
-claude-code-watcher setup
+cc-jsonl setup
 
 # View current configuration
 cat ~/.config/cc-jsonl/settings.json
@@ -183,7 +203,8 @@ cat ~/.config/cc-jsonl/settings.json
 ```json
 {
   "databaseFileName": "/home/user/.config/cc-jsonl/data.db",
-  "watchTargetDir": "/home/user/.claude/projects"
+  "watchTargetDir": "/home/user/.claude/projects",
+  "port": 3000
 }
 ```
 
@@ -197,11 +218,11 @@ cat ~/.config/cc-jsonl/settings.json
 # Set default directory for log processing
 export WATCH_TARGET_DIR=/path/to/claude-logs
 
-# Use environment variable (when directory is not specified)
-claude-code-watcher batch  # Uses WATCH_TARGET_DIR
+# Use environment variable (when --targetDirectory is not specified)
+cc-jsonl batch  # Uses WATCH_TARGET_DIR
 
-# Override environment variable
-claude-code-watcher batch /custom/path
+# Override environment variable with explicit option
+cc-jsonl batch --targetDirectory /custom/path
 ```
 
 ### .env File Configuration
@@ -218,19 +239,22 @@ WATCH_TARGET_DIR=/home/user/claude-code-logs
 ### First Time Setup
 ```bash
 # Complete initialization process
-npm install -g claude-code-watcher
-claude-code-watcher setup
+npm install -g cc-jsonl
+cc-jsonl setup
+cc-jsonl build
 
-# Custom setup with specific paths
-claude-code-watcher setup --databaseFile /srv/data/claude.db --watchDir /var/log/claude
+# Custom setup with specific paths and port
+cc-jsonl setup --databaseFile /srv/data/claude.db --watchDir /var/log/claude --port 8080
+cc-jsonl build
 ```
 
 ### Production Server Operations
 ```bash
 # Install, setup, and start production server
-npm install -g claude-code-watcher
-claude-code-watcher setup
-claude-code-watcher start --port 8080
+npm install -g cc-jsonl
+cc-jsonl setup
+cc-jsonl build
+cc-jsonl start --port 8080
 ```
 
 ### Log Processing Workflows
@@ -238,25 +262,25 @@ claude-code-watcher start --port 8080
 #### Bulk Processing of Past Logs
 ```bash
 # Process large backlog of accumulated logs
-claude-code-watcher batch -c 15 --no-skipExisting /archive/claude-logs
+cc-jsonl batch --targetDirectory /archive/claude-logs -c 15 --skipExisting false
 ```
 
 #### Real-time Monitoring
 ```bash
 # Monitor active log directory every 10 minutes
-claude-code-watcher watch -i 10 -c 8 /active/claude-logs
+cc-jsonl watch --targetDirectory /active/claude-logs -i 10 -c 8
 ```
 
 #### Selective File Processing
 ```bash
 # Process only 2024 session files
-claude-code-watcher batch -p "session-2024-*.jsonl" /logs/2024
+cc-jsonl batch --targetDirectory /logs/2024 -p "session-2024-*.jsonl"
 ```
 
 #### High-Performance Processing
 ```bash
 # Maximum efficiency processing for large datasets
-claude-code-watcher batch -c 20 --pattern "*.jsonl" /massive-logs
+cc-jsonl batch --targetDirectory /massive-logs -c 20 --pattern "*.jsonl"
 ```
 
 ## Performance Tuning
@@ -283,10 +307,10 @@ claude-code-watcher batch -c 20 --pattern "*.jsonl" /massive-logs
 
 ```bash
 # Check global installation
-npm list -g claude-code-watcher
+npm list -g cc-jsonl
 
 # Reinstall if needed
-npm install -g claude-code-watcher
+npm install -g cc-jsonl
 
 # Check PATH includes npm global bin
 echo $PATH
@@ -296,7 +320,7 @@ echo $PATH
 
 ```bash
 # On Linux/macOS, you may need sudo for global install
-sudo npm install -g claude-code-watcher
+sudo npm install -g cc-jsonl
 
 # Or configure npm to use different directory
 npm config set prefix ~/.local
@@ -310,7 +334,7 @@ export PATH=~/.local/bin:$PATH
 ls -la /path/to/claude-logs
 
 # Verify file pattern is correct
-claude-code-watcher batch --help
+cc-jsonl batch --help
 ```
 
 ### Production Server Won't Start
@@ -320,14 +344,17 @@ claude-code-watcher batch --help
 lsof -i :3000
 
 # Use different port
-claude-code-watcher start --port 3001
+cc-jsonl start --port 3001
 ```
 
 ### Configuration Issues
 
 ```bash
 # Re-run setup if configuration is corrupted
-claude-code-watcher setup --force
+cc-jsonl setup --force
+
+# Re-run setup with custom settings
+cc-jsonl setup --databaseFile /custom/path/data.db --watchDir /custom/logs --port 8080 --force
 
 # Check configuration file location
 ls -la ~/.config/cc-jsonl/settings.json
@@ -337,43 +364,52 @@ ls -la ~/.config/cc-jsonl/data.db
 
 # Reset to defaults
 rm ~/.config/cc-jsonl/settings.json
-claude-code-watcher setup
+cc-jsonl setup
 ```
 
 ### Help and Debug Information
 
 ```bash
 # Show CLI version and available commands
-claude-code-watcher --help
+cc-jsonl --help
 
 # Show help for individual commands
-claude-code-watcher setup --help
-claude-code-watcher batch --help
-claude-code-watcher watch --help
-claude-code-watcher start --help
+cc-jsonl setup --help
+cc-jsonl build --help
+cc-jsonl batch --help
+cc-jsonl watch --help
+cc-jsonl start --help
 ```
 
 ## Common Command Patterns
 
 ### Initial Setup
 ```bash
-npm install -g claude-code-watcher   # Install globally
-claude-code-watcher --version        # Verify operation
-claude-code-watcher setup            # Initialize configuration and database
+npm install -g cc-jsonl   # Install globally
+cc-jsonl --version        # Verify operation
+cc-jsonl setup            # Initialize configuration and database
+cc-jsonl build            # Build application for production
 ```
 
 ### Daily Operations
 ```bash
-claude-code-watcher start            # Start server (port 3000)
-claude-code-watcher batch           # Process logs (uses configured directory)
-claude-code-watcher watch           # Start continuous monitoring
+cc-jsonl start            # Start server (uses configured port, default 3000)
+cc-jsonl batch           # Process logs (uses configured watch directory)
+cc-jsonl watch           # Start continuous monitoring (uses configured directory)
+
+# Or specify options explicitly
+cc-jsonl start --port 8080
+cc-jsonl batch --targetDirectory /path/to/logs
+cc-jsonl watch --targetDirectory /path/to/logs --interval 30
 ```
 
 ### Troubleshooting
 ```bash
-claude-code-watcher --help          # Check all commands
-claude-code-watcher batch --help    # Detailed batch help
-npm list -g claude-code-watcher     # Check installation
+cc-jsonl --help          # Check all commands
+cc-jsonl setup --help    # Detailed setup help
+cc-jsonl build --help    # Detailed build help
+cc-jsonl batch --help    # Detailed batch help
+npm list -g cc-jsonl     # Check installation
 ```
 
 ## Development

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -113,17 +113,17 @@ Document current progress, issues, and next steps here.
   - **Usage Examples:**
     ```bash
     # Development workflow
-    claude-code-watcher dev --port 3001 --no-turbo
-    claude-code-watcher build
-    claude-code-watcher start --port 8080
+    cc-jsonl dev --port 3001 --no-turbo
+    cc-jsonl build
+    cc-jsonl start --port 8080
     
     # Database management
-    claude-code-watcher db generate
-    claude-code-watcher db migrate
+    cc-jsonl db generate
+    cc-jsonl db migrate
     
     # Log processing
-    claude-code-watcher batch -c 10 /path/to/logs
-    claude-code-watcher watch -i 30 /path/to/logs
+    cc-jsonl batch -c 10 /path/to/logs
+    cc-jsonl watch -i 30 /path/to/logs
     ```
   - Testing: All TypeScript checks pass, comprehensive CLI testing completed, all commands functional
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "claude-code-watcher",
+  "name": "cc-jsonl",
   "version": "0.1.0",
   "description": "Unified CLI for Claude Code production server and log processing",
   "main": "./dist/index.js",
   "bin": {
-    "claude-code-watcher": "./dist/cli.mjs"
+    "cc-jsonl": "./dist/cli.mjs"
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -461,7 +461,7 @@ const setupCommand = define({
 });
 
 const mainCommand = define({
-  name: "claude-code-watcher",
+  name: "cc-jsonl",
   description: "CLI for Claude Code production server and log processing",
   run: (_ctx) => {
     console.log("Claude Code Unified CLI");
@@ -494,7 +494,7 @@ async function main() {
     subCommands.set("start", startCommand);
 
     await cli(process.argv.slice(2), mainCommand, {
-      name: "claude-code-watcher",
+      name: "cc-jsonl",
       version: "1.0.0",
       description: "CLI for Claude Code production server and log processing",
       subCommands,


### PR DESCRIPTION
## Summary

This PR implements issue #53, renaming the package and CLI command from `claude-code-watcher` to `cc-jsonl` to better reflect its purpose as a JSONL log processor for Claude Code sessions.

### Key Changes

- **Package Name**: `claude-code-watcher` → `cc-jsonl`
- **CLI Command**: `claude-code-watcher` → `cc-jsonl`
- **Binary Name**: Updated in package.json
- **Documentation**: Comprehensive update of README.md and all examples

### Documentation Improvements

- ✅ Added missing `build` command documentation
- ✅ Fixed CLI argument specifications (positional → named options)
- ✅ Added missing `--port` option for `setup` command
- ✅ Corrected all usage examples with proper option syntax
- ✅ Updated configuration file format documentation
- ✅ Enhanced troubleshooting and help sections

### Files Modified

- `package.json` - Package name and binary configuration
- `src/cli/cli.ts` - CLI command name
- `README.md` - Complete documentation overhaul
- `docs/progress.md` - Historical documentation updates

### Breaking Changes

This is a breaking change for users who have installed the previous version:

```bash
# Old usage (no longer works)
claude-code-watcher setup

# New usage
cc-jsonl setup
```

## Test Plan

- [x] TypeScript type checking passes
- [x] Biome linting passes
- [x] All tests pass (172 tests)
- [x] CLI functionality verified
- [x] Documentation accuracy confirmed

🤖 Generated with [Claude Code](https://claude.ai/code)